### PR TITLE
Basic CRUD Operations for Tasks using Firestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ fabric.properties
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
+.vscode

--- a/backend/firebase.json
+++ b/backend/firebase.json
@@ -3,6 +3,11 @@
     "predeploy": [
       "npm --prefix functions run lint",
       "npm --prefix functions run build"
-    ]
+    ],
+    "source": "functions"
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -1,9 +1,55 @@
 import * as functions from "firebase-functions";
-
-// // Start writing Firebase Functions
-// // https://firebase.google.com/docs/functions/typescript
+import * as admin from "firebase-admin";
+import {TaskTypeNoID} from "./types";
+admin.initializeApp();
+// Start writing Firebase Functions
+// https://firebase.google.com/docs/functions/typescript
 //
 export const helloWorld = functions.https.onRequest((request, response) => {
   functions.logger.info("Hello logs!", {structuredData: true});
   response.send("Hello from Firebase!");
 });
+
+export const createTask = functions.https
+    .onRequest(async (request, response) => {
+      const {title, description} = request.body;
+      const task: TaskTypeNoID = {
+        title,
+        description,
+        createdAt: new Date().toISOString(),
+      };
+      const ref = await admin.firestore().collection("tasks").add(task);
+      response.send(ref.id);
+    });
+
+export const getTask = functions.https
+    .onRequest(async (request, response) => {
+      const id = request.query.id as string;
+      const ref = await admin.firestore().collection("tasks").doc(id).get();
+      response.send(ref.data());
+    }
+    );
+
+export const updateTask = functions.https
+    .onRequest(async (request, response) => {
+      const id = request.query.id as string;
+      const {title, description} = request.body;
+      const ref = await admin.firestore().collection("tasks").doc(id);
+      await ref.update({
+        title,
+        description,
+        updatedAt: new Date().toISOString(),
+      });
+      response.send("ok");
+    }
+    );
+
+export const deleteTask = functions.https
+    .onRequest(async (request, response) => {
+      const id = request.query.id as string;
+      const ref = await admin.firestore().collection("tasks").doc(id);
+      await ref.delete();
+      response.send("ok");
+    }
+    );
+

--- a/backend/functions/src/types.ts
+++ b/backend/functions/src/types.ts
@@ -1,0 +1,13 @@
+export type TaskTypeNoID = {
+  title: string;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: Date;
+}
+
+export type TaskTypeWithID = {
+  title: string;
+  description?: string;
+  createdAt?: string;
+  updatedAt?: Date;
+}

--- a/backend/functions/src/types.ts
+++ b/backend/functions/src/types.ts
@@ -7,6 +7,7 @@ export type TaskTypeNoID = {
 
 export type TaskTypeWithID = {
   title: string;
+  id: string;
   description?: string;
   createdAt?: string;
   updatedAt?: Date;


### PR DESCRIPTION
Adds a basic implementation of CRUD for Tasks.

Current Task Schematic: 

`TaskTypeNoID: {
  title: string;
  description?: string;
  createdAt?: string;
  updatedAt?: Date;
}`

`TaskTypeWithID: {
  title: string;
  id: string;
  description?: string;
  createdAt?: string;
  updatedAt?: Date;
}`

Adds endpoints: 

POST `/createTask` takes JSON body: {title, description}, returns Task ID
GET `/getTask` takes query parameter id. ie. /getTask?id=asdf1234, returns a TaskWithID
PUT `/updateTask` takes JSON body: {title, description}, returns ok on successful update
DELETE `/deleteTask` takes query parameter id. ie. /getTask?id=asdf1234, returns ok on successful delete

Testing instructions:

`cd backend/functions`
`npm run build`
`cd ..`
`firebase emulator:start`

these commands will start a local emulator of the firestore, as well as the function endpoints. 
Use a REST Software like Postman to test queries to these endpoints.
